### PR TITLE
Fix gradient propagation for period parameter and add validation suite

### DIFF
--- a/examples/gradient_check_period.py
+++ b/examples/gradient_check_period.py
@@ -113,10 +113,12 @@ def run_jax(mode, shape_type):
     else:
         ad_arr = np.array(ad_grad)
         fd_arr = np.array(fd_grad)
-        
+
     diff = np.abs(ad_arr - fd_arr).max()
     if diff < 1e-4:
         print(f"    PASSED (Diff: {diff:.2e})")
+        print(f"    AD: {ad_grad}")
+        print(f"    FD: {fd_grad}")
     else:
         print(f"    FAILED (Diff: {diff:.2e})")
         print(f"    AD: {ad_grad}")
@@ -223,6 +225,8 @@ def run_torch(mode, shape_type):
     
     if diff < 1e-4:
         print(f"    PASSED (Diff: {diff:.2e})")
+        print(f"    AD: {ad_grad}")
+        print(f"    FD: {fd_grad}")
     else:
         print(f"    FAILED (Diff: {diff:.2e})")
         print(f"    AD: {ad_grad}")

--- a/examples/gradient_check_period.py
+++ b/examples/gradient_check_period.py
@@ -1,0 +1,247 @@
+import torch
+import jax
+import jax.numpy as jnp
+import numpy as np
+import meent
+
+def get_ucell(mode, backend):
+    # simple pattern
+    # 1D: (1, 1, 10)
+    # 2D: (1, 10, 10)
+    if mode == '1D':
+        # 1 layer, y=1, x=10
+        ucell = np.array([[[1.0]*5 + [1.5]*5]]) 
+    else: # 2D
+        # 1 layer, y=10, x=10
+        x = np.array([[1.0]*5 + [1.5]*5])
+        ucell = np.repeat(x, 10, axis=0).reshape(1, 10, 10)
+        
+    if backend == 1: # JAX
+        return jnp.array(ucell)
+    else: # Torch
+        return torch.tensor(ucell, dtype=torch.float64)
+
+def run_jax(mode, shape_type):
+    print(f"  Testing JAX, mode={mode}, shape={shape_type}")
+    
+    ucell = get_ucell(mode, 1)
+    
+    def loss_fn(p):
+        # p is whatever structure jax.grad passes down (list of tracers, array tracer, etc.)
+        fto = [1, 0] if mode == '1D' else [1, 1]
+        mee = meent.call_mee(backend=1, period=p, ucell=ucell,
+                             wavelength=900., thickness=[500.], fto=fto,
+                             n_top=1., n_bot=1.5)
+        res = mee.conv_solve()
+        return jnp.sum(res.res.de_ri)
+
+    val = 1000.
+    
+    if shape_type == 'scalar':
+        p_init = val
+    elif shape_type == 'vector_1':
+        p_init = jnp.array([val])
+    elif shape_type == 'vector_2':
+        p_init = jnp.array([val, val])
+    elif shape_type == 'list_1':
+        p_init = [val]
+    elif shape_type == 'list_2':
+        p_init = [val, val]
+        
+    # JAX Grad
+    # For list input, we need to ensure jax treats it correctly. 
+    # jax.grad differentiates w.r.t first argument.
+    grad_fn = jax.grad(loss_fn)
+    
+    try:
+        ad_grad = grad_fn(p_init)
+    except Exception as e:
+        print(f"    FAILED AD: {e}")
+        # import traceback
+        # traceback.print_exc()
+        return
+
+    # Finite Difference
+    eps = 1e-4
+    
+    # Helper to compute FD
+    def compute_loss_val(p_in):
+        # We need to wrap scalar in array if needed for consistent loss_fn calls?
+        # No, loss_fn handles what we pass.
+        return loss_fn(p_in)
+
+    fd_grad = None
+
+    if shape_type == 'scalar':
+         l_plus = compute_loss_val(p_init + eps)
+         l_minus = compute_loss_val(p_init - eps)
+         fd_grad = (l_plus - l_minus) / (2 * eps)
+         
+    elif shape_type.startswith('vector'):
+         p_val = np.array(p_init)
+         grad_flat = []
+         for i in range(p_val.size):
+             p_plus = p_val.flatten()
+             p_plus[i] += eps
+             p_plus = p_plus.reshape(p_val.shape)
+             
+             p_minus = p_val.flatten()
+             p_minus[i] -= eps
+             p_minus = p_minus.reshape(p_val.shape)
+
+             l_p = compute_loss_val(jnp.array(p_plus))
+             l_m = compute_loss_val(jnp.array(p_minus))
+             grad_flat.append((l_p - l_m) / (2*eps))
+         fd_grad = np.array(grad_flat).reshape(p_val.shape)
+         
+    elif shape_type.startswith('list'):
+         grad_list = []
+         for i in range(len(p_init)):
+             p_plus = list(p_init)
+             p_plus[i] += eps
+             p_minus = list(p_init)
+             p_minus[i] -= eps
+             l_p = compute_loss_val(p_plus)
+             l_m = compute_loss_val(p_minus)
+             grad_list.append((l_p - l_m)/(2*eps))
+         fd_grad = grad_list
+
+    # Compare
+    if isinstance(ad_grad, list):
+        ad_arr = np.array(ad_grad)
+        fd_arr = np.array(fd_grad)
+    else:
+        ad_arr = np.array(ad_grad)
+        fd_arr = np.array(fd_grad)
+        
+    diff = np.abs(ad_arr - fd_arr).max()
+    if diff < 1e-4:
+        print(f"    PASSED (Diff: {diff:.2e})")
+    else:
+        print(f"    FAILED (Diff: {diff:.2e})")
+        print(f"    AD: {ad_grad}")
+        print(f"    FD: {fd_grad}")
+
+def run_torch(mode, shape_type):
+    print(f"  Testing Torch, mode={mode}, shape={shape_type}")
+    
+    ucell = get_ucell(mode, 2)
+    
+    val = 1000.
+    
+    if shape_type == 'scalar':
+        p = torch.tensor(val, dtype=torch.float64, requires_grad=True)
+    elif shape_type == 'vector_1':
+        p = torch.tensor([val], dtype=torch.float64, requires_grad=True)
+    elif shape_type == 'vector_2':
+        p = torch.tensor([val, val], dtype=torch.float64, requires_grad=True)
+    elif shape_type == 'list_1':
+        p = [torch.tensor(val, dtype=torch.float64, requires_grad=True)]
+    elif shape_type == 'list_2':
+        p = [torch.tensor(val, dtype=torch.float64, requires_grad=True) for _ in range(2)]
+
+    def loss_fn(p_in):
+        fto = [1, 0] if mode == '1D' else [1, 1]
+        mee = meent.call_mee(backend=2, period=p_in, ucell=ucell,
+                             wavelength=900., thickness=[500.], fto=fto,
+                             n_top=1., n_bot=1.5)
+        res = mee.conv_solve()
+        return res.res.de_ri.sum()
+
+    # AD
+    try:
+        loss = loss_fn(p)
+        loss.backward()
+    except Exception as e:
+        print(f"    FAILED AD: {e}")
+        return
+    
+    if isinstance(p, list):
+        ad_grad = [pi.grad.item() for pi in p]
+    else:
+        ad_grad = p.grad.detach().numpy()
+        
+    # FD
+    eps = 1e-4
+    
+    def compute_loss_val_torch(p_vals):
+        # p_vals is list of floats or scalar float or array
+        # we need to reconstruct input
+        if shape_type == 'scalar':
+             return loss_fn(torch.tensor(p_vals, dtype=torch.float64))
+        elif shape_type.startswith('vector'):
+             return loss_fn(torch.tensor(p_vals, dtype=torch.float64))
+        elif shape_type.startswith('list'):
+             # pass list of tensors (constants)
+             return loss_fn([torch.tensor(v, dtype=torch.float64) for v in p_vals])
+    
+    fd_grad = None
+    
+    with torch.no_grad():
+        if shape_type == 'scalar':
+             p_val = p.item()
+             l_p = compute_loss_val_torch(p_val + eps)
+             l_m = compute_loss_val_torch(p_val - eps)
+             fd_grad = (l_p - l_m).item()/(2*eps)
+             
+        elif shape_type.startswith('vector'):
+             p_val = p.detach().numpy()
+             grad_flat = []
+             for i in range(p_val.size):
+                 p_plus = p_val.flatten()
+                 p_plus[i] += eps
+                 p_plus = p_plus.reshape(p_val.shape)
+                 
+                 p_minus = p_val.flatten()
+                 p_minus[i] -= eps
+                 p_minus = p_minus.reshape(p_val.shape)
+                 
+                 l_p = compute_loss_val_torch(p_plus)
+                 l_m = compute_loss_val_torch(p_minus)
+                 grad_flat.append((l_p - l_m).item()/(2*eps))
+             fd_grad = np.array(grad_flat).reshape(p_val.shape)
+             
+        elif shape_type.startswith('list'):
+             grad_list = []
+             p_vals = [pi.item() for pi in p]
+             for i in range(len(p_vals)):
+                 p_plus = list(p_vals)
+                 p_plus[i] += eps
+                 
+                 p_minus = list(p_vals)
+                 p_minus[i] -= eps
+                 
+                 l_p = compute_loss_val_torch(p_plus)
+                 l_m = compute_loss_val_torch(p_minus)
+                 grad_list.append((l_p - l_m).item()/(2*eps))
+             fd_grad = grad_list
+
+    # Compare
+    ad_arr = np.array(ad_grad)
+    fd_arr = np.array(fd_grad)
+    diff = np.abs(ad_arr - fd_arr).max()
+    
+    if diff < 1e-4:
+        print(f"    PASSED (Diff: {diff:.2e})")
+    else:
+        print(f"    FAILED (Diff: {diff:.2e})")
+        print(f"    AD: {ad_grad}")
+        print(f"    FD: {fd_grad}")
+
+if __name__ == '__main__':
+    print("========================================")
+    print("Gradient Check for Period Parameter")
+    print("========================================")
+    
+    shapes = ['scalar', 'vector_1', 'vector_2', 'list_1', 'list_2']
+    modes = ['1D', '2D']
+    
+    print("\n--- JAX Backend ---")
+    for mode in modes:
+        for shape in shapes:
+            run_jax(mode, shape)
+            
+    print("\n--- PyTorch Backend ---")
+    for mode in modes:
+        for shape in shapes:
+            run_torch(mode, shape)

--- a/examples/gradient_check_period.py
+++ b/examples/gradient_check_period.py
@@ -28,7 +28,7 @@ def run_jax(mode, shape_type):
     
     def loss_fn(p):
         # p is whatever structure jax.grad passes down (list of tracers, array tracer, etc.)
-        fto = [1, 0] if mode == '1D' else [1, 1]
+        fto = [5, 0] if mode == '1D' else [5, 5]
         mee = meent.call_mee(backend=1, period=p, ucell=ucell,
                              wavelength=900., thickness=[500.], fto=fto,
                              n_top=1., n_bot=1.5)
@@ -141,7 +141,7 @@ def run_torch(mode, shape_type):
         p = [torch.tensor(val, dtype=torch.float64, requires_grad=True) for _ in range(2)]
 
     def loss_fn(p_in):
-        fto = [1, 0] if mode == '1D' else [1, 1]
+        fto = [5, 0] if mode == '1D' else [5, 5]
         mee = meent.call_mee(backend=2, period=p_in, ucell=ucell,
                              wavelength=900., thickness=[500.], fto=fto,
                              n_top=1., n_bot=1.5)

--- a/examples/gradient_check_period.py
+++ b/examples/gradient_check_period.py
@@ -13,8 +13,9 @@ def get_ucell(mode, backend):
         ucell = np.array([[[1.0]*5 + [1.5]*5]]) 
     else: # 2D
         # 1 layer, y=10, x=10
-        x = np.array([[1.0]*5 + [1.5]*5])
-        ucell = np.repeat(x, 10, axis=0).reshape(1, 10, 10)
+        # Checkerboard-like pattern (square in middle)
+        ucell = np.ones((1, 10, 10)) * 1.0
+        ucell[0, 2:8, 2:8] = 1.5
         
     if backend == 1: # JAX
         return jnp.array(ucell)

--- a/examples/gradient_check_period.py
+++ b/examples/gradient_check_period.py
@@ -5,15 +5,26 @@ import numpy as np
 import meent
 
 def get_ucell(mode, backend):
-    # simple pattern
-    # 1D: (1, 1, 10)
-    # 2D: (1, 10, 10)
+    """
+    Generates the unit cell (refractive index distribution) for the simulation.
+    
+    Args:
+        mode (str): '1D' or '2D'.
+        backend (int): 1 for JAX, 2 for PyTorch.
+        
+    Returns:
+        Tensor/Array: The unit cell structure.
+    """
+    # Simple pattern generation
+    # 1D: (1, 1, 10) - extruded along y, varying along x
+    # 2D: (1, 10, 10) - varying along both x and y
     if mode == '1D':
-        # 1 layer, y=1, x=10
+        # 1 layer, y=1, x=10. Simple binary grating.
         ucell = np.array([[[1.0]*5 + [1.5]*5]]) 
     else: # 2D
-        # 1 layer, y=10, x=10
-        # Checkerboard-like pattern (square in middle)
+        # 1 layer, y=10, x=10. 
+        # Checkerboard-like pattern (square in middle) to ensure sensitivity to both X and Y periods.
+        # If the pattern were invariant in Y (like a 1D grating in 2D sim), dL/dTy would be 0.
         ucell = np.ones((1, 10, 10)) * 1.0
         ucell[0, 2:8, 2:8] = 1.5
         
@@ -23,21 +34,35 @@ def get_ucell(mode, backend):
         return torch.tensor(ucell, dtype=torch.float64)
 
 def run_jax(mode, shape_type):
+    """
+    Runs gradient check for JAX backend.
+    """
     print(f"  Testing JAX, mode={mode}, shape={shape_type}")
     
     ucell = get_ucell(mode, 1)
     
     def loss_fn(p):
-        # p is whatever structure jax.grad passes down (list of tracers, array tracer, etc.)
+        """
+        Calculates total reflection efficiency.
+        Jax will differentiate this function w.r.t 'p'.
+        """
+        # Set Fourier orders (fto) based on mode.
+        # 1D: [5, 0] means 11 orders in X, 0 in Y.
+        # 2D: [5, 5] means 11 orders in X, 11 in Y.
         fto = [5, 0] if mode == '1D' else [5, 5]
+        
+        # Call meent. 'period' is passed as 'p'.
         mee = meent.call_mee(backend=1, period=p, ucell=ucell,
                              wavelength=900., thickness=[500.], fto=fto,
                              n_top=1., n_bot=1.5)
         res = mee.conv_solve()
+        
+        # Loss: Sum of reflection efficiencies (Diffraction Efficiency - Reflection - Intensity)
         return jnp.sum(res.res.de_ri)
 
     val = 1000.
     
+    # Initialize 'period' in various shapes to test robustness
     if shape_type == 'scalar':
         p_init = val
     elif shape_type == 'vector_1':
@@ -49,36 +74,33 @@ def run_jax(mode, shape_type):
     elif shape_type == 'list_2':
         p_init = [val, val]
         
-    # JAX Grad
-    # For list input, we need to ensure jax treats it correctly. 
-    # jax.grad differentiates w.r.t first argument.
+    # --- Automatic Differentiation (AD) ---
+    # jax.grad returns a function that computes the gradient of loss_fn w.r.t its first argument.
     grad_fn = jax.grad(loss_fn)
     
     try:
         ad_grad = grad_fn(p_init)
     except Exception as e:
         print(f"    FAILED AD: {e}")
-        # import traceback
-        # traceback.print_exc()
         return
 
-    # Finite Difference
+    # --- Finite Difference (FD) ---
     eps = 1e-4
     
-    # Helper to compute FD
+    # Helper to compute loss without gradient tracking (standard execution)
     def compute_loss_val(p_in):
-        # We need to wrap scalar in array if needed for consistent loss_fn calls?
-        # No, loss_fn handles what we pass.
         return loss_fn(p_in)
 
     fd_grad = None
 
     if shape_type == 'scalar':
+         # Central difference for scalar
          l_plus = compute_loss_val(p_init + eps)
          l_minus = compute_loss_val(p_init - eps)
          fd_grad = (l_plus - l_minus) / (2 * eps)
          
     elif shape_type.startswith('vector'):
+         # Central difference for each element of the vector
          p_val = np.array(p_init)
          grad_flat = []
          for i in range(p_val.size):
@@ -96,6 +118,7 @@ def run_jax(mode, shape_type):
          fd_grad = np.array(grad_flat).reshape(p_val.shape)
          
     elif shape_type.startswith('list'):
+         # Central difference for each element of the list
          grad_list = []
          for i in range(len(p_init)):
              p_plus = list(p_init)
@@ -107,7 +130,7 @@ def run_jax(mode, shape_type):
              grad_list.append((l_p - l_m)/(2*eps))
          fd_grad = grad_list
 
-    # Compare
+    # --- Comparison ---
     if isinstance(ad_grad, list):
         ad_arr = np.array(ad_grad)
         fd_arr = np.array(fd_grad)
@@ -116,6 +139,8 @@ def run_jax(mode, shape_type):
         fd_arr = np.array(fd_grad)
 
     diff = np.abs(ad_arr - fd_arr).max()
+    
+    # Check if difference is within tolerance
     if diff < 1e-4:
         print(f"    PASSED (Diff: {diff:.2e})")
         print(f"    AD: {ad_grad}")
@@ -126,12 +151,16 @@ def run_jax(mode, shape_type):
         print(f"    FD: {fd_grad}")
 
 def run_torch(mode, shape_type):
+    """
+    Runs gradient check for PyTorch backend.
+    """
     print(f"  Testing Torch, mode={mode}, shape={shape_type}")
     
     ucell = get_ucell(mode, 2)
     
     val = 1000.
     
+    # Initialize 'period' with requires_grad=True to enable AD
     if shape_type == 'scalar':
         p = torch.tensor(val, dtype=torch.float64, requires_grad=True)
     elif shape_type == 'vector_1':
@@ -144,43 +173,48 @@ def run_torch(mode, shape_type):
         p = [torch.tensor(val, dtype=torch.float64, requires_grad=True) for _ in range(2)]
 
     def loss_fn(p_in):
+        # Set Fourier orders
         fto = [5, 0] if mode == '1D' else [5, 5]
+        
+        # Call meent
         mee = meent.call_mee(backend=2, period=p_in, ucell=ucell,
                              wavelength=900., thickness=[500.], fto=fto,
                              n_top=1., n_bot=1.5)
         res = mee.conv_solve()
         return res.res.de_ri.sum()
 
-    # AD
+    # --- Automatic Differentiation (AD) ---
     try:
         loss = loss_fn(p)
-        loss.backward()
+        loss.backward() # Computes gradients and stores them in p.grad
     except Exception as e:
         print(f"    FAILED AD: {e}")
         return
     
+    # Extract gradient values
     if isinstance(p, list):
         ad_grad = [pi.grad.item() for pi in p]
     else:
         ad_grad = p.grad.detach().numpy()
         
-    # FD
+    # --- Finite Difference (FD) ---
     eps = 1e-4
     
+    # Helper for FD
     def compute_loss_val_torch(p_vals):
-        # p_vals is list of floats or scalar float or array
-        # we need to reconstruct input
+        # p_vals contains raw values (floats/arrays).
+        # We assume they are effectively constant for the purpose of loss evaluation here.
         if shape_type == 'scalar':
              return loss_fn(torch.tensor(p_vals, dtype=torch.float64))
         elif shape_type.startswith('vector'):
              return loss_fn(torch.tensor(p_vals, dtype=torch.float64))
         elif shape_type.startswith('list'):
-             # pass list of tensors (constants)
+             # pass list of tensors
              return loss_fn([torch.tensor(v, dtype=torch.float64) for v in p_vals])
     
     fd_grad = None
     
-    with torch.no_grad():
+    with torch.no_grad(): # Disable grad for FD steps
         if shape_type == 'scalar':
              p_val = p.item()
              l_p = compute_loss_val_torch(p_val + eps)
@@ -219,7 +253,7 @@ def run_torch(mode, shape_type):
                  grad_list.append((l_p - l_m).item()/(2*eps))
              fd_grad = grad_list
 
-    # Compare
+    # --- Compare ---
     ad_arr = np.array(ad_grad)
     fd_arr = np.array(fd_grad)
     diff = np.abs(ad_arr - fd_arr).max()

--- a/meent/on_jax/emsolver/_base.py
+++ b/meent/on_jax/emsolver/_base.py
@@ -209,6 +209,8 @@ class _BaseRCWA:
         if type(period) in (int, float):
             self._period = jnp.array([period, period], dtype=self.type_float)
         elif type(period) in (list, tuple, np.ndarray) or isinstance(period, jnp.ndarray):
+            # Support for JAX Tracers (e.g., from jax.grad)
+            # Scalar tracers have ndim=0 and do not support len(), which would raise TypeError.
             if hasattr(period, 'ndim') and period.ndim == 0:
                 self._period = jnp.array([period, period], dtype=self.type_float)
             elif len(period) == 1:

--- a/meent/on_jax/emsolver/_base.py
+++ b/meent/on_jax/emsolver/_base.py
@@ -209,9 +209,13 @@ class _BaseRCWA:
         if type(period) in (int, float):
             self._period = jnp.array([period, period], dtype=self.type_float)
         elif type(period) in (list, tuple, np.ndarray) or isinstance(period, jnp.ndarray):
-            if len(period) == 1:
+            if hasattr(period, 'ndim') and period.ndim == 0:
+                self._period = jnp.array([period, period], dtype=self.type_float)
+            elif len(period) == 1:
                 period = [period[0], period[0]]
-            self._period = jnp.array(period, dtype=self.type_float)
+                self._period = jnp.array(period, dtype=self.type_float)
+            else:
+                self._period = jnp.array(period, dtype=self.type_float)
         elif type(period) is jax.interpreters.partial_eval.DynamicJaxprTracer:
             print('init period')
             jax.debug.print('init period')

--- a/meent/on_torch/emsolver/_base.py
+++ b/meent/on_torch/emsolver/_base.py
@@ -193,6 +193,8 @@ class _BaseRCWA:
     @period.setter
     def period(self, period):
         if isinstance(period, torch.Tensor):
+            # Maintain the autograd graph by using graph-preserving operations (view, repeat)
+            # instead of creating a new leaf tensor with torch.tensor().
             if period.ndim == 0:
                 p = period.view(1).repeat(2)
             elif period.numel() == 1:
@@ -202,7 +204,7 @@ class _BaseRCWA:
             self._period = p.to(device=self.device, dtype=self.type_float)
 
         elif type(period) in (list, tuple, np.ndarray):
-            # Check if elements are tensors
+            # Check if elements are tensors to preserve the autograd graph using torch.stack().
             if len(period) > 0 and isinstance(period[0], torch.Tensor):
                 if len(period) == 1:
                     p = torch.stack([period[0], period[0]])

--- a/meent/on_torch/emsolver/_base.py
+++ b/meent/on_torch/emsolver/_base.py
@@ -192,12 +192,29 @@ class _BaseRCWA:
 
     @period.setter
     def period(self, period):
-        if type(period) in (int, float):
+        if isinstance(period, torch.Tensor):
+            if period.ndim == 0:
+                p = period.view(1).repeat(2)
+            elif period.numel() == 1:
+                p = period.view(1).repeat(2)
+            else:
+                p = period
+            self._period = p.to(device=self.device, dtype=self.type_float)
+
+        elif type(period) in (list, tuple, np.ndarray):
+            # Check if elements are tensors
+            if len(period) > 0 and isinstance(period[0], torch.Tensor):
+                if len(period) == 1:
+                    p = torch.stack([period[0], period[0]])
+                else:
+                    p = torch.stack([period[0], period[1]])
+                self._period = p.to(device=self.device, dtype=self.type_float)
+            else:
+                if len(period) == 1:
+                    period = [period[0], period[0]]
+                self._period = torch.tensor(period, device=self.device, dtype=self.type_float)
+        elif type(period) in (int, float):
             self._period = torch.tensor([period, period], device=self.device, dtype=self.type_float)
-        elif type(period) in (list, tuple, np.ndarray) or isinstance(period, torch.Tensor):
-            if len(period) == 1:
-                period = [period[0], period[0]]
-            self._period = torch.tensor(period, device=self.device, dtype=self.type_float)
         else:
             raise ValueError
 


### PR DESCRIPTION
### Description
  This PR resolves an issue where gradients with respect to the period parameter were not correctly propagating in both the JAX and PyTorch backends. Additionally, it introduces a comprehensive example script to validate these gradients against numerical finite difference results.

### Changes
#### Core Library Fixes
   * PyTorch Backend: Modified the period setter in _BaseRCWA to use graph-preserving operations (view, repeat, and torch.stack). Previously, the use of torch.tensor() created new leaf tensors, which detached the autograd graph and prevented gradient flow back to the input parameters.
   * JAX Backend: Fixed a TypeError in the period setter occurring when scalar Tracers (e.g., from jax.grad) were passed. Since 0-rank JAX arrays do not support len(), the logic was updated to use an ndim check for proper broadcasting.
   * Documentation: Added detailed internal comments to the modified setters explaining the necessity of these changes for maintaining gradient integrity.

#### Validation Suite
   * New Example: Added examples/gradient_check_period.py, a robust script that validates AD gradients against Central Finite Difference (FD) approximations.
   * Coverage:
       * Backends: Validates both JAX and PyTorch implementations.
       * Modes: Tests both 1D and 2D simulations.
       * Input Types: Ensures correctness for period passed as a scalar, a 1D vector (array), or a list of values/tensors.
   * Sensitivity: The 2D test case uses a checkerboard pattern to ensure that gradients for both $p_x$ and $p_y$ are properly calculated and verified.
   * Observability: The script now outputs both the calculated gradient magnitudes and the absolute difference between AD and FD for easier debugging and verification.

#### Verification Results
  Validated the fixes using the new examples/gradient_check_period.py script. In all tested configurations (1D/2D, JAX/Torch, multiple Fourier orders), the AD gradients match the FD results with a precision of approximately $10^{-5}$ to $10^{-6}$.

  ---
  **Disclaimer: This pull request and the associated code modifications were prepared with the assistance of gemini-cli.**