### PR TITLE
Fix torch GPU backend: use torch.sin instead of np.sin on device tensors

### DIFF
--- a/meent/on_torch/emsolver/_base.py
+++ b/meent/on_torch/emsolver/_base.py
@@ -228,7 +228,7 @@ class _BaseRCWA:
             sin_theta = torch.sin(
                 torch.nextafter(torch.float32(torch.pi / 2), torch.float32(0)) + self.theta.imag * np.complex64(1j))
         else:
-            sin_theta = np.sin(self.theta)
+            sin_theta = torch.sin(self.theta)
 
         if self.phi is None:
             phi = torch.tensor(0, device=self.device, dtype=self.type_complex)


### PR DESCRIPTION
## Problem

`_BaseRCWA.get_kx_ky_vector()` in `meent/on_torch/emsolver/_base.py` computes `sin_theta` with `np.sin(self.theta)`. When `theta` is on a CUDA device this raises:

```
TypeError: can't convert cuda:0 device type tensor to numpy.
           Use Tensor.cpu() to copy the tensor to host memory first.
```

Because `get_kx_ky_vector()` is on the path of essentially every solve, this makes `device=1` (GPU) unusable on the torch backend. `tutorials/03-device-and-datatype-torch.ipynb` fails on its first GPU cell.

## Fix

Use `torch.sin`, which keeps the computation on-device and is already what the sibling branch a few lines above uses:

```python
if self.theta.real >= torch.tensor(torch.pi/2, dtype=torch.float32):
    sin_theta = torch.sin(...)          # already torch.sin
else:
    sin_theta = np.sin(self.theta)      # <-- fails on CUDA tensors
```

One line, no API or behavior change on CPU.

## Verification

On an RTX 5090, `torch 2.11.0+cu128`, Python 3.12:

- GPU `conv_solve()` now runs, and agrees with the CPU result to `max|GPU-CPU| = 9.1e-14` (float64) — numerically identical, not just crash-free.
- `tutorials/03-device-and-datatype-torch.ipynb` completes end to end. Resulting timings (seconds):

  | Config | efficiency | field | combined |
  |---|---|---|---|
  | CPU, 64-bit | 7.24 | 1.55 | 8.86 |
  | GPU, 64-bit | 3.43 | 0.088 | 3.54 |
  | CPU, 32-bit | 3.17 | 0.578 | 3.64 |
  | GPU, 32-bit | 0.45 | 0.011 | 0.46 |

- `tutorials/02-autograd-and-optimization-pytorch.ipynb` still passes (no CPU regression).

## Note

While testing the JAX backend on current `jaxlib` I hit a separate, unrelated issue: the device setter in `meent/on_jax/emsolver/_base.py` compares `str(type(device[0])) == "<class 'jaxlib.xla_extension.Device'>"`, but modern jaxlib reports `jaxlib._jax.Device`, so passing a device list raises `ValueError`. I've left that out of this PR since a robust fix depends on which `jax` versions you want to keep supporting (`jax.Device` postdates your declared `jax>=0.4.1` floor). Happy to open a separate PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)