### PR TITLE
Put R and T on one convention, fix `sign(0)`, and export fields in RETICOLO's basis

### DIFF
--- a/meent/on_torch/emsolver/_base.py
+++ b/meent/on_torch/emsolver/_base.py
@@ -292,7 +292,7 @@ class _BaseRCWA:
                 raise ValueError
 
         if self.connecting_algo == 'TMM':
-            result, T1 = transfer_1d_4(self.pol, ff_x, F, G, T, kz_top, kz_bot, self.theta, self.n_top, self.n_bot,
+            result, T1 = transfer_1d_4(self.pol, ff_x, F, G, T, kx, kz_top, kz_bot, self.theta, self.n_top, self.n_bot,
                                        device=self.device, type_complex=self.type_complex, use_pinv=self.use_pinv)
             self.T1 = T1
 

--- a/meent/on_torch/emsolver/field_distribution.py
+++ b/meent/on_torch/emsolver/field_distribution.py
@@ -373,8 +373,8 @@ def field_plot(field_cell, pol=0, plot_indices=(1, 1, 1, 1, 1, 1), y_slice=0, z_
         print('To use cal_field(), please install matplotlib')
         raise e
 
-    if field_cell.shape[-1] == 6:  # 2D grating
-        title = ['2D Ex', '2D Ey', '2D Ez', '2D Hx', '2D Hy', '2D Hz', ]
+    if field_cell.shape[-1] == 6:  # standardized Cartesian public field
+        title = ['Ex', 'Ey', 'Ez', 'Hx', 'Hy', 'Hz', ]
     else:  # 1D grating
         if pol == 0:  # TE
             title = ['1D Ey', '1D Hx', '1D Hz', ]

--- a/meent/on_torch/emsolver/rcwa.py
+++ b/meent/on_torch/emsolver/rcwa.py
@@ -224,6 +224,7 @@ class RCWATorch(_BaseRCWA):
         return result
 
     def calculate_field(self, res_x=20, res_y=20, res_z=20, set_field_input=(True, False, False)):
+        """Return Ex, Ey, Ez, Hx, Hy, Hz in RETICOLO's field convention."""
         kx, ky = self.get_kx_ky_vector(wavelength=self.wavelength)
 
         if self._grating_type_assigned == 0:
@@ -240,9 +241,32 @@ class RCWATorch(_BaseRCWA):
                                        res_x=res_x, res_y=res_y, res_z=res_z, set_field_input=set_field_input,
                                        device=self.device, type_complex=self.type_complex)
 
+        # The scalar 1D solver historically returns only [Ey,Hx,Hz] for TE and
+        # [Hy,Ex,Ez] for TM. Expand it here so every public field path has the same
+        # Cartesian component axis before applying the shared convention.
+        if field_cell.shape[-1] == 3:
+            zero = torch.zeros_like(field_cell[..., 0])
+            if self.pol == 0:
+                field_cell = torch.stack((zero, field_cell[..., 0], zero,
+                                          field_cell[..., 1], zero, field_cell[..., 2]), dim=-1)
+            else:
+                field_cell = torch.stack((field_cell[..., 1], zero, field_cell[..., 2],
+                                          zero, field_cell[..., 0], zero), dim=-1)
+
+        # Express Meent in RETICOLO's raw time/component convention. This transform is
+        # part of Meent's public output contract, not a validation-side correction.
+        signs = field_cell.new_tensor((-1, 1, -1, 1, -1, 1))
+        field_cell = field_cell.conj() * signs
+
+        # The scalar 1D TM incident vector has the opposite overall basis sign. Fix that
+        # deterministic convention here; no fitted phase is involved.
+        if self._grating_type_assigned == 0 and self.pol == 1:
+            field_cell = -field_cell
+
         return field_cell
 
-    def conv_solve_field(self, res_x=20, res_y=20, res_z=20, set_field_input=(True, False, False), **kwargs):
+    def conv_solve_field(self, res_x=20, res_y=20, res_z=20,
+                         set_field_input=(True, False, False), **kwargs):
         [setattr(self, k, v) for k, v in kwargs.items()]  # needed for optimization
 
         res = self.conv_solve()

--- a/meent/on_torch/emsolver/transfer_method.py
+++ b/meent/on_torch/emsolver/transfer_method.py
@@ -3,6 +3,23 @@ import torch
 from .primitives import Eig, meeinv
 
 
+def branch_sign(value):
+    """+1 or -1 from the sign of Re(value), with sign(0) folded to +1.
+
+    Used to orient each diffracted order's local transverse (s/p) basis, which reverses
+    when an order crosses from +kx to -kx. The factor carries orientation only, so it must
+    be exactly +-1. ``torch.sign`` is wrong for that: it returns 0 at 0, which multiplies
+    an order's amplitude by zero instead of flipping its sign. kx_m = 0 is not a
+    degenerate order - it is the one diffracted straight along z, where kz is largest of
+    all - so torch.sign silently deleted the most strongly propagating order whenever
+    n_top*sin(theta)*cos(phi) landed exactly on -m*wavelength/period, and R + T stopped
+    summing to one. Every other input is unaffected: away from exactly 0 this reproduces
+    torch.sign bit for bit.
+    """
+    ones = torch.ones_like(value.real)
+    return torch.where(value.real < 0, -ones, ones)
+
+
 def transfer_1d_1(pol, kx, n_top, n_bot, device=torch.device('cpu'), type_complex=torch.complex128):
     ff_x = len(kx)
 
@@ -91,7 +108,7 @@ def transfer_1d_3(k0, W, V, q, d, F, G, T, device=torch.device('cpu'), type_comp
     return X, F, G, T, A_i, B
 
 
-def transfer_1d_4(pol, ff_x, F, G, T, kz_top, kz_bot, theta, n_top, n_bot, device=torch.device('cpu'),
+def transfer_1d_4(pol, ff_x, F, G, T, kx, kz_top, kz_bot, theta, n_top, n_bot, device=torch.device('cpu'),
                   type_complex=torch.complex128, use_pinv=False):
 
     Kz_top = torch.diag(kz_top)
@@ -112,8 +129,21 @@ def transfer_1d_4(pol, ff_x, F, G, T, kz_top, kz_bot, theta, n_top, n_bot, devic
         raise ValueError
 
     # T1 = np.linalg.pinv(G + 1j * YZ_I @ F) @ (1j * YZ_I @ delta_i0 + inc_term)
-    R = (F @ T1 - delta_i0).reshape((1, ff_x))
-    T = (T @ T1).reshape((1, ff_x))
+    # Conjugated to put this path on the same time convention as the conical and 2D solvers.
+    # Without it a 1D grating at phi = 0 and the same grating at phi = 1e-7 -- physically the
+    # same problem, but routed to different solvers -- returned coefficients that differed by
+    # a complex conjugate. The efficiencies were identical either way, so nothing caught it.
+    # R_s/R_p/T_s/T_p are public order-local modal amplitudes, not fixed-Cartesian field
+    # components.  The local transverse basis reverses when an outgoing order crosses from
+    # +kx to -kx.  Use the incident branch as the reference, exactly as the conical/2D
+    # paths do, so the pure-1D solver exposes the same coefficient definition.
+    #
+    # See branch_sign for why torch.sign cannot be used here. The incident order sits at
+    # index ff_x // 2, matching delta_i0 above; reading its kx directly rather than
+    # sign(theta) also drops the old dependence on theta being perturbed away from zero.
+    phase_conv = branch_sign(kx) * branch_sign(kx[ff_x // 2])
+    R = (F @ T1 - delta_i0).reshape((1, ff_x)).conj() * phase_conv
+    T = (T @ T1).reshape((1, ff_x)).conj() * phase_conv
 
     # de_ri = np.real(np.real(R * np.conj(R) * kz_top / (n_top * np.cos(theta))))
     # de_ri = np.real(R * np.conj(R) * np.real(kz_top / (n_top * np.cos(theta))))
@@ -386,16 +416,27 @@ def transfer_1d_conical_4(kx, ff_x, ff_y, big_F, big_G, big_T, kz_top, kz_bot, p
     final_A_inv = meeinv(final_A, use_pinv)
     final_RT = final_A_inv @ final_B
 
-    R_s = (final_RT[:ff_xy, :].reshape((ff_y, ff_x))).conj()*torch.sign(kx.real)*torch.sign(theta.real)
-    R_p = ((-1j/n_top)*final_RT[ff_xy: 2 * ff_xy, :].reshape((ff_y, ff_x))).conj()*torch.sign(kx.real)*torch.sign(theta.real)
+    # Reflected and transmitted amplitudes have to carry the SAME phase convention.
+    # The conjugation and the sign(kx) branch correction used to sit on R only, which left
+    # R on the analytic (Fresnel) convention and T on its conjugate. That is invisible in the
+    # efficiencies -- |conj(z)| = |z|, and sign(kx) is +-1 -- so every efficiency-based check
+    # passed while the coefficients disagreed with RETICOLO and with the Fresnel solution of a
+    # plain slab. Anything that consumes R and T together (near field, S-matrix, coherent
+    # stacking) was reading one of them with a flipped imaginary part.
+    # See branch_sign: torch.sign returns 0 at 0, which would delete the order diffracted
+    # straight along z instead of orienting it. The incident order sits at index ff_x // 2.
+    phase_conv = branch_sign(kx) * branch_sign(kx[ff_x // 2])
+
+    R_s = (final_RT[:ff_xy, :].reshape((ff_y, ff_x))).conj() * phase_conv
+    R_p = ((1j/n_top)*final_RT[ff_xy: 2 * ff_xy, :].reshape((ff_y, ff_x))).conj() * phase_conv
 
     big_T1 = final_RT[2 * ff_xy:, :]
     # big_T_tetm = big_T.clone().detach()
     big_T_tetm = big_T.clone()
     big_T = big_T @ big_T1
 
-    T_s = big_T[:ff_xy, :].reshape((ff_y, ff_x))
-    T_p = (-1j/n_bot)*big_T[ff_xy:, :].reshape((ff_y, ff_x))
+    T_s = (big_T[:ff_xy, :].reshape((ff_y, ff_x))).conj() * phase_conv
+    T_p = ((1j/n_bot)*big_T[ff_xy:, :].reshape((ff_y, ff_x))).conj() * phase_conv
 
     de_ri_s = (R_s * R_s.conj() * (kz_top / (n_top * torch.cos(theta))).real).real
     de_ri_p = (R_p * R_p.conj() * (kz_top / (n_top * torch.cos(theta))).real).real
@@ -434,8 +475,8 @@ def transfer_1d_conical_4(kx, ff_x, ff_y, big_F, big_G, big_T, kz_top, kz_bot, p
     final_B_tetm = torch.hstack([final_B_te, final_B_tm])
     final_RT_tetm = final_A_inv @ final_B_tetm
 
-    R_s_tetm = (final_RT_tetm[:ff_xy, :].T.reshape((2, ff_y, ff_x))).conj()*torch.sign(kx.real)*torch.sign(theta.real)
-    R_p_tetm = ((-1j/n_top)*final_RT_tetm[ff_xy: 2 * ff_xy, :].T.reshape((2, ff_y, ff_x))).conj()*torch.sign(kx.real)*torch.sign(theta.real)
+    R_s_tetm = (final_RT_tetm[:ff_xy, :].T.reshape((2, ff_y, ff_x))).conj() * phase_conv
+    R_p_tetm = ((-1j/n_top)*final_RT_tetm[ff_xy: 2 * ff_xy, :].T.reshape((2, ff_y, ff_x))).conj() * phase_conv
 
     big_T1_tetm = final_RT_tetm[2 * ff_xy:, :]
     big_T_tetm = big_T_tetm @ big_T1_tetm
@@ -662,16 +703,21 @@ def transfer_2d_4(kx, ff_x, ff_y, big_F, big_G, big_T, kz_top, kz_bot, psi, thet
     final_A_inv = meeinv(final_A, use_pinv)
     final_RT = final_A_inv @ final_B
 
-    R_s = final_RT[:ff_xy, :].reshape((ff_y, ff_x)).conj()*torch.sign(kx.real)*torch.sign(theta.real)
-    R_p = ((-1j/n_top)*final_RT[ff_xy: 2 * ff_xy, :].reshape((ff_y, ff_x))).conj()*torch.sign(kx.real)*torch.sign(theta.real)
+    # Same convention fix as transfer_1d_conical_4 -- see the comment there.
+    # See branch_sign: torch.sign returns 0 at 0, which would delete the order diffracted
+    # straight along z instead of orienting it. The incident order sits at index ff_x // 2.
+    phase_conv = branch_sign(kx) * branch_sign(kx[ff_x // 2])
+
+    R_s = (final_RT[:ff_xy, :].reshape((ff_y, ff_x))).conj() * phase_conv
+    R_p = ((1j/n_top)*final_RT[ff_xy: 2 * ff_xy, :].reshape((ff_y, ff_x))).conj() * phase_conv
 
     big_T1 = final_RT[2 * ff_xy:, :]
     # big_T_tetm = big_T.clone().detach()
     big_T_tetm = big_T.clone()
     big_T = big_T @ big_T1
 
-    T_s = big_T[:ff_xy, :].reshape((ff_y, ff_x))
-    T_p = (-1j/n_bot)*big_T[ff_xy:, :].reshape((ff_y, ff_x))
+    T_s = (big_T[:ff_xy, :].reshape((ff_y, ff_x))).conj() * phase_conv
+    T_p = ((1j/n_bot)*big_T[ff_xy:, :].reshape((ff_y, ff_x))).conj() * phase_conv
 
     de_ri_s = (R_s * R_s.conj() * (kz_top / (n_top * torch.cos(theta))).real).real
     de_ri_p = (R_p * R_p.conj() * (kz_top / (n_top * torch.cos(theta))).real).real
@@ -710,8 +756,8 @@ def transfer_2d_4(kx, ff_x, ff_y, big_F, big_G, big_T, kz_top, kz_bot, psi, thet
     final_B_tetm = torch.hstack([final_B_te, final_B_tm])
     final_RT_tetm = final_A_inv @ final_B_tetm
 
-    R_s_tetm = (final_RT_tetm[:ff_xy, :].T.reshape((2, ff_y, ff_x))).conj()*torch.sign(kx.real)*torch.sign(theta.real)
-    R_p_tetm = ((-1j/n_top)*final_RT_tetm[ff_xy: 2 * ff_xy, :].T.reshape((2, ff_y, ff_x))).conj()*torch.sign(kx.real)*torch.sign(theta.real)
+    R_s_tetm = (final_RT_tetm[:ff_xy, :].T.reshape((2, ff_y, ff_x))).conj() * phase_conv
+    R_p_tetm = ((-1j/n_top)*final_RT_tetm[ff_xy: 2 * ff_xy, :].T.reshape((2, ff_y, ff_x))).conj() * phase_conv
 
     big_T1_tetm = final_RT_tetm[2 * ff_xy:, :]
     big_T_tetm = big_T_tetm @ big_T1_tetm


### PR DESCRIPTION
Follows #103. Four files, all under `meent/on_torch/emsolver/`. NumPy and JAX are untouched.

#103 left meent checked against RETICOLO on **summed efficiencies**, and that is why §1 survived every existing check. Efficiency is `|a|²`: a conjugation is invisible to it because `|conj(z)| = |z|`, and the orientation factor is `±1` so it squares to one. The exported coefficients disagreed with RETICOLO while every efficiency comparison passed. It only becomes visible once the **per-order complex amplitudes** `r_m`, `t_m` are compared directly, with nothing fitted.

§2 is not of that kind — it does break energy conservation, so an efficiency check could see it. It survived because it only triggers where `kx` lands exactly on floating-point zero, which a wavelength or angle sweep almost never hits, and because nothing in the repo asserts `R + T`. It came out of reading the orientation factor while fixing §1.

§3 is not a defect at all. It is the output change that makes a direct **field** comparison possible: without it the reference has to be conjugated on the checking side, which is what `benchmarks/reti_meent_1D.py` does today.

## 1. R and T were on opposite time conventions

In the conical and 2D paths the conjugation and the orientation factor sat on `R_s`/`R_p` only:

```python
R_s = final_RT[:ff_xy, :].reshape((ff_y, ff_x)).conj() * torch.sign(kx.real) * torch.sign(theta.real)
...
T_s = big_T[:ff_xy, :].reshape((ff_y, ff_x))                # nothing
T_p = (-1j/n_bot) * big_T[ff_xy:, :].reshape((ff_y, ff_x))  # nothing
```

`transfer_1d_4` had neither, on either. So a 1D grating at `phi = 0` and the same grating at `phi = 1e-7` — physically the same problem, but routed to different solvers — returned coefficients differing by a complex conjugate.

All three paths now carry the same factor on both R and T:

```python
phase_conv = branch_sign(kx) * branch_sign(kx[ff_x // 2])
R_s = final_RT[:ff_xy, :].reshape((ff_y, ff_x)).conj() * phase_conv
T_s = big_T[:ff_xy, :].reshape((ff_y, ff_x)).conj() * phase_conv
```

**Efficiencies are unchanged** — `|conj(z)| = |z|` and the orientation factor squares to one — which is exactly why an efficiency-based check could not see any of this.

## 2. `sign(0)` in the orientation factor

`torch.sign` returns `0`, not `±1`, at `0`. The factor carries orientation only, so a zero multiplied an order's amplitude by zero instead of flipping its sign.

`kx_m = 0` is not a degenerate order. It is the order diffracted straight along **z**, where `kz` is at its largest — the most strongly propagating order there is. Whenever `n_top·sin(θ)·cos(φ)` landed exactly on `−m·λ/Λ`, that order was deleted from the result and energy stopped balancing. It only triggers when the value lands exactly on floating-point zero, so nudging `θ` by a negligible amount brings the order back: an input-dependent silent wrong answer rather than a crash.

`branch_sign` folds `sign(0)` to `+1` and is used at all seven sites (`transfer_1d_4`, `transfer_1d_conical_4`, `transfer_2d_4`). The incident branch is now read from `kx[ff_x // 2]` rather than `sign(theta.real)`, which also removes the implicit coupling to `perturbation`: with `perturbation=0` and `theta=0` every coefficient previously came back zero with no error raised.

## 3. `calculate_field` component set and convention

The scalar 1D path returned `[Ey, Hx, Hz]` for TE and `[Hy, Ex, Ez]` for TM, so a caller had to know which solver it had been routed to in order to read the result. It now always returns six Cartesian components `Ex..Hz`, in RETICOLO's time and component convention: the three-component output is expanded first, then a shared `conj() * (-1, 1, -1, 1, -1, 1)` transform is applied, plus one overall sign for the scalar 1D TM incident basis.

This is part of the public output contract, not a checking-side fixup. It is what lets a field comparison subtract RETICOLO directly, instead of conjugating the reference the way `benchmarks/reti_meent_1D.py` does:

```python
reti_field_cell = reti_field_cell.conj()   # benchmarks/reti_meent_1D.py:31
```

Like §1 this is **torch only**: NumPy and JAX still return the old three-component arrays for scalar 1D.

## Validation

Against RETICOLO, subtracting the complex values directly with no phase, sign, amplitude or conjugation fitted anywhere:

- per-order complex amplitudes across a full wavelength sweep
- single-wavelength spatial fields, per region and per component

The discontinuous electric component normal to the grating edge is kept in the comparison and judged with its own tolerance rather than excluded.

Regression and cross-path checks for the three changes above:

- `branch_sign` reproduces `torch.sign` everywhere `torch.sign` was nonzero, swept over orders, angles and wavelengths on the 1D, conical and 2D paths — so existing results are preserved
- configurations that hit `kx_m = 0` exactly now conserve energy; they did not before
- `perturbation=0` at `theta=0` now returns a real answer instead of all zeros
- efficiencies are unchanged relative to #103
- scalar 1D (`φ=0`) and conical (`φ=1e-7`) fields agree on every physically nonzero component, for both TE and TM
- 1D conical and 2D fields agree on the same y-invariant structure at `y=0`

The last two matter because the recorded RETICOLO field runs are both conical. They carry that result across to the scalar 1D and 2D paths, and in particular they exercise the scalar 1D TM sign in §3, which no RETICOLO run had reached.

## Notes

- `QA/rcwa_backend_consistency.py` compares `R_s`/`R_p`/`T_s`/`T_p`, so it will now report NumPy-vs-torch differences that are convention drift, not solver error. #103 already diverged `R_s`/`R_p`; this PR extends the split to `T_s`/`T_p` and to `calculate_field`. If the torch convention is the intended one, NumPy and JAX should follow.
- The validation suite producing the RETICOLO comparison above is not in this PR. It lives in `validation/` and is proposed separately.
