### PR TITLE
Keep the autograd graph on every differentiable solver input

### DIFF
--- a/meent/on_torch/emsolver/_base.py
+++ b/meent/on_torch/emsolver/_base.py
@@ -10,6 +10,29 @@ from .transfer_method import (transfer_1d_1, transfer_1d_2, transfer_1d_3, trans
                               transfer_2d_1, transfer_2d_2, transfer_2d_3, transfer_2d_4)
 
 
+def _to_tensor(value, device, dtype):
+    """``value`` as a tensor, keeping its autograd graph if it already carries one.
+
+    ``torch.tensor()`` copies the values out of a tensor and returns a new leaf, so any
+    setter written that way silently detaches a parameter the caller meant to optimize.
+    The failure is quiet in the case that matters: with a differentiable ``ucell`` the loss
+    still has a ``grad_fn`` through the cell, so ``backward()`` succeeds and only this
+    parameter's ``.grad`` stays ``None`` - and ``torch.optim`` skips a parameter whose grad
+    is ``None``, so it never moves while the run looks healthy.
+
+    A list is handled too, because a per-layer quantity is naturally written as
+    ``[t, 200e-9]``. Values that carry no graph take the plain ``torch.tensor`` path.
+    """
+    if isinstance(value, torch.Tensor):
+        return value.to(device=device, dtype=dtype)
+    if isinstance(value, (list, tuple)) and any(isinstance(v, torch.Tensor) for v in value):
+        return torch.stack([v.to(device=device, dtype=dtype).reshape(())
+                            if isinstance(v, torch.Tensor)
+                            else torch.tensor(v, device=device, dtype=dtype)
+                            for v in value])
+    return torch.tensor(value, device=device, dtype=dtype)
+
+
 class _BaseRCWA:
     def __init__(self, n_top=1., n_bot=1., theta=0., phi=None, psi=None, pol=0., fto=(0, 0),
                  period=(1., 1.), wavelength=1.,
@@ -110,7 +133,7 @@ class _BaseRCWA:
         if theta is None:
             self._theta = None
         else:
-            self._theta = torch.tensor(theta, device=self.device, dtype=self.type_complex)
+            self._theta = _to_tensor(theta, self.device, self.type_complex)
             self._theta = torch.where(self._theta == 0, self.perturbation, self._theta)  # perturbation
 
     @property
@@ -122,7 +145,7 @@ class _BaseRCWA:
         if phi is None:
             self._phi = None
         else:
-            self._phi = torch.tensor(phi, device=self.device, dtype=self.type_complex)
+            self._phi = _to_tensor(phi, self.device, self.type_complex)
 
     @property
     def psi(self):
@@ -131,9 +154,10 @@ class _BaseRCWA:
     @psi.setter
     def psi(self, psi):
         if psi is not None:
-            self._psi = torch.tensor(psi, dtype=self.type_complex)
-            pol = -(2 * psi / torch.pi - 1)
-            self._pol = pol
+            self._psi = _to_tensor(psi, self.device, self.type_complex)
+            # Derived from the stored tensor, not the raw argument, so pol follows psi onto
+            # the same device and dtype and keeps the graph with it.
+            self._pol = -(2 * self._psi / torch.pi - 1)
 
     @property
     def pol(self):
@@ -195,9 +219,12 @@ class _BaseRCWA:
         if type(period) in (int, float):
             self._period = torch.tensor([period, period], device=self.device, dtype=self.type_float)
         elif type(period) in (list, tuple, np.ndarray) or isinstance(period, torch.Tensor):
-            if len(period) == 1:
-                period = [period[0], period[0]]
-            self._period = torch.tensor(period, device=self.device, dtype=self.type_float)
+            # A single period means a 1D grating and is duplicated onto both axes. Do that
+            # by concatenating the stored tensor rather than by rebuilding a list, so a
+            # differentiable period reaches both axes through the same graph.
+            self._period = _to_tensor(period, self.device, self.type_float)
+            if len(self._period) == 1:
+                self._period = torch.cat([self._period, self._period])
         else:
             raise ValueError
 
@@ -209,10 +236,8 @@ class _BaseRCWA:
     def thickness(self, thickness):
         if type(thickness) in (int, float):
             self._thickness = torch.tensor([thickness], device=self.device, dtype=self.type_float)
-        elif type(thickness) in (list, tuple, np.ndarray):
-            self._thickness = torch.tensor(thickness, device=self.device, dtype=self.type_float)
-        elif type(thickness) is torch.Tensor:
-            self._thickness = thickness.to(device=self.device, dtype=self.type_float)
+        elif type(thickness) in (list, tuple, np.ndarray) or isinstance(thickness, torch.Tensor):
+            self._thickness = _to_tensor(thickness, self.device, self.type_float)
         else:
             raise ValueError
 


### PR DESCRIPTION
Follows #106. One file, `meent/on_torch/emsolver/_base.py`. Found while checking that #106 had not broken backprop.

## The problem

Setters that stored their argument through `torch.tensor()` silently detached it — that call copies the values out of a tensor and returns a new leaf. So a parameter the caller meant to optimize arrived at the solver with no graph:

```python
self._theta     = torch.tensor(theta, device=self.device, dtype=self.type_complex)
self._phi       = torch.tensor(phi, device=self.device, dtype=self.type_complex)
self._psi       = torch.tensor(psi, dtype=self.type_complex)
self._period    = torch.tensor(period, device=self.device, dtype=self.type_float)
self._thickness = torch.tensor(thickness, device=self.device, dtype=self.type_float)
```

`thickness` is the odd one out: the branch taking a whole `torch.Tensor` already used `.to()` and kept the graph. What it lost was a per-layer thickness written as a list — which is the natural way to write it when the thickness is what you are optimizing:

```python
t = torch.tensor(300e-9, requires_grad=True)   # layer 1 thickness, the parameter
thickness = [t, 200e-9]                        # layer 1 optimized, layer 2 fixed
```

The list itself is not a tensor and only one element is, so it missed the `.to()` branch, fell through to `torch.tensor(...)`, and lost the graph. Every `t` below means this.

The failure is quiet in the case that matters. On its own a detached parameter raises on `backward()`, which is at least loud. But in an optimization where the `ucell` is also differentiable, the loss still has a `grad_fn` through the cell: `backward()` succeeds, `ucell.grad` fills in, and only that parameter's `.grad` stays `None`. `torch.optim` skips a parameter whose grad is `None`, so it never moves while the run looks healthy.

Affected: `theta`, `phi`, `psi`, `period` and `thickness`. `period` was the worst — its list/tuple/ndarray branch also caught `torch.Tensor`, so it was detached however it was passed and could not be optimized at all. `ucell`, `wavelength`, `n_top` and `n_bot` already carried gradients and are untouched.

## The change

All five setters need the same handling, so it lives in one `_to_tensor` rather than being repeated five times. Three branches:

```python
def _to_tensor(value, device, dtype):
    # 1. Already a tensor: convert with .to(), which keeps the graph.
    if isinstance(value, torch.Tensor):
        return value.to(device=device, dtype=dtype)

    # 2. A list with a tensor in it. A per-layer quantity is naturally written as
    #    [t, 200e-9], where the list itself is not a tensor but an element is.
    if isinstance(value, (list, tuple)) and any(isinstance(v, torch.Tensor) for v in value):
        return torch.stack([...])

    # 3. Nothing carrying a graph: the original path, unchanged.
    return torch.tensor(value, device=device, dtype=dtype)
```

Two follow-on details: `period` duplicates a single entry onto both axes by concatenating the stored tensor rather than rebuilding a list, and `psi` derives `pol` from the stored tensor. Both keep those values on the graph and on the right device.

## Validation

An Adam loop optimizing `ucell` and `thickness` together, thickness passed as `[t, 200e-9]`: before, the reflectance improved every step, `t.grad` stayed `None` and the thickness ended on exactly its starting value. After, the thickness moves and the same loop reaches a better reflectance.

Every input that carries a gradient — `theta`, `phi`, `psi`, `period`, `thickness`, `wavelength`, `n_top`, `n_bot` — was checked against central finite differences and agrees. `ucell` still does too. `theta`, `phi`, `psi` and `period` previously returned `None` here.

No change for inputs that carry no graph:

- `period` as float / `list[1]` / `list[2]` / tuple / ndarray / Tensor, and `thickness` as float / list / tuple / ndarray / Tensor: same stored values, `R + T = 1` throughout
- `theta=0` still substitutes `perturbation`, `phi=None` still stores `None`, `pol=1.5` still raises, and `psi` at `0` and `pi/2` still reduce to `pol=1` and `pol=0` on the scalar 1D path
- 1D, conical and 2D all conserve energy, and `calculate_field` returns the same shapes

## Notes

- torch only, like the rest of `_base.py` here. The NumPy and JAX backends have no autograd graph to preserve.
- `calculate_field` was checked to run and produce a gradient for `theta` and `period`, but only the `conv_solve` gradients above were compared against finite differences.
